### PR TITLE
Add broadcast of block to peers

### DIFF
--- a/block.py
+++ b/block.py
@@ -30,5 +30,5 @@ class Block(VariablePayload):
         self.merkle_tree.recalculate_tree()
         self.merkle_hash = self.merkle_tree.get_root_hash()
 
-    def get_merkle_hash(self) -> bytes:
+    def get_merkle_hash(self) -> str:
         return self.merkle_hash

--- a/block.py
+++ b/block.py
@@ -3,21 +3,24 @@ import hashlib
 from merkle_tree import MerkleTree
 from ipv8.messaging.serialization import default_serializer
 from ipv8.messaging.lazy_payload import VariablePayload
+from ipv8.messaging.serialization import default_serializer
 
 class Block(VariablePayload):
-    format_list = ['74s', '74s', 'payload-list']
+    format_list = ['varlenHutf8', 'varlenHutf8', 'varlenH-list']
     names = ['previous_hash', 'merkle_hash', 'transactions']
 
-    def __init__(self, previous_hash: bytes = b''):
-        self.previous_hash = previous_hash
-        self.transactions = []
+    def __init__(self, previous_hash: str = '', merkle_hash: str = '', transactions = []):
+        self.previous_hash = str(previous_hash)
+        self.transactions = transactions if len(transactions) > 0 else []
         self.merkle_tree = MerkleTree()
-        self.merkle_hash = b''
+        self.merkle_hash = merkle_hash if merkle_hash != '' else ''
 
     def add_transaction(self, transaction):
-        self.transactions.append(transaction)
-        serialized_data = default_serializer.pack_serializable(transaction)
-        transaction_hash = hashlib.sha256(serialized_data).hexdigest()
+        # We serialize the transaction before appending it to the array
+        # because there seems to be an ipv8 problem when it tries to serialize the whole array
+        serialized_transaction = default_serializer.pack_serializable(transaction)
+        self.transactions.append(serialized_transaction)
+        transaction_hash = hashlib.sha256(serialized_transaction).hexdigest()
         self.merkle_tree.add_leaf(transaction_hash)
 
     def is_full(self):

--- a/block.py
+++ b/block.py
@@ -1,33 +1,31 @@
 import hashlib
 
 from merkle_tree import MerkleTree
-import pickle
+from ipv8.messaging.serialization import default_serializer
+from ipv8.messaging.lazy_payload import VariablePayload
 
+class Block(VariablePayload):
+    format_list = ['74s', '74s', 'payload-list']
+    names = ['previous_hash', 'merkle_hash', 'transactions']
 
-class Block:
-    def __init__(self, previous_hash, transactions=None):
+    def __init__(self, previous_hash: bytes = b''):
         self.previous_hash = previous_hash
-        self.transactions = transactions if transactions is not None else []
+        self.transactions = []
         self.merkle_tree = MerkleTree()
+        self.merkle_hash = b''
 
     def add_transaction(self, transaction):
         self.transactions.append(transaction)
-        serialized_data = self.serialize(transaction)
+        serialized_data = default_serializer.pack_serializable(transaction)
         transaction_hash = hashlib.sha256(serialized_data).hexdigest()
         self.merkle_tree.add_leaf(transaction_hash)
 
     def is_full(self):
-        return len(self.transactions) >= 10
+        return len(self.transactions) >= 2
 
-    def serialize(self, transaction) -> bytes:
-        return pickle.dumps({
-            'sender': transaction.sender,
-            'receiver': transaction.receiver,
-            'amount': transaction.amount,
-            'nonce': transaction.nonce,
-            'ttl': transaction.ttl
-        })
+    def update_tree(self):
+        self.merkle_tree.recalculate_tree()
+        self.merkle_hash = self.merkle_tree.get_root_hash()
 
-    def __reduce__(self):
-        # Customizing pickling for Block class
-        return (self.__class__, (self.previous_hash, self.merkle_tree))
+    def get_merkle_hash(self) -> bytes:
+        return self.merkle_hash

--- a/block.py
+++ b/block.py
@@ -24,7 +24,7 @@ class Block(VariablePayload):
         self.merkle_tree.add_leaf(transaction_hash)
 
     def is_full(self):
-        return len(self.transactions) >= 2
+        return len(self.transactions) >= 10
 
     def update_tree(self):
         self.merkle_tree.recalculate_tree()

--- a/main.py
+++ b/main.py
@@ -54,7 +54,6 @@ class MyCommunity(Community):
         self.add_message_handler(BlockMessage, self.receive_block)
 
     def started(self, id) -> None:
-        print('Community started', self.get_peer_id(self.my_peer))
         logging.info('Community started')
 
         # Testing purpose

--- a/merkle_tree.py
+++ b/merkle_tree.py
@@ -2,7 +2,7 @@ import hashlib
 
 
 class MerkleNode:
-    def __init__(self, hash):
+    def __init__(self, hash: bytes):
         self.hash = hash
         self.parent = None
         self.left_child = None
@@ -12,12 +12,13 @@ class MerkleNode:
 class MerkleTree:
     def __init__(self):
         self.leaves = []
-        self.root = None
+        self.root: MerkleNode = None
 
     def add_leaf(self, leaf_hash):
         new_leaf = MerkleNode(leaf_hash)
         self.leaves.append(new_leaf)
-        self.recalculate_tree()
+        # Do we need to calculate the tree everytime we add a leaf?
+        # self.recalculate_tree()
 
     def recalculate_tree(self):
         nodes = self.leaves
@@ -28,7 +29,7 @@ class MerkleTree:
                 right_child = nodes[i + 1] if i + 1 < len(nodes) else None
                 if right_child:
                     node_hash = hashlib.sha256((left_child.hash + right_child.hash).encode('utf-8')).hexdigest()
-                    parent_node = MerkleNode(node_hash)
+                    parent_node = MerkleNode(node_hash.encode('utf-8'))
                     parent_node.left_child, parent_node.right_child = left_child, right_child
                     left_child.parent = parent_node
                     right_child.parent = parent_node
@@ -38,5 +39,5 @@ class MerkleTree:
             nodes = new_level
         self.root = nodes[0]
 
-    def get_root_hash(self):
-        return self.root.hash if self.root else ''
+    def get_root_hash(self) -> bytes:
+        return self.root.hash if self.root else b''

--- a/merkle_tree.py
+++ b/merkle_tree.py
@@ -17,8 +17,6 @@ class MerkleTree:
     def add_leaf(self, leaf_hash):
         new_leaf = MerkleNode(leaf_hash)
         self.leaves.append(new_leaf)
-        # Do we need to calculate the tree everytime we add a leaf?
-        # self.recalculate_tree()
 
     def recalculate_tree(self):
         nodes = self.leaves

--- a/merkle_tree.py
+++ b/merkle_tree.py
@@ -2,7 +2,7 @@ import hashlib
 
 
 class MerkleNode:
-    def __init__(self, hash: bytes):
+    def __init__(self, hash: str):
         self.hash = hash
         self.parent = None
         self.left_child = None
@@ -29,7 +29,7 @@ class MerkleTree:
                 right_child = nodes[i + 1] if i + 1 < len(nodes) else None
                 if right_child:
                     node_hash = hashlib.sha256((left_child.hash + right_child.hash).encode('utf-8')).hexdigest()
-                    parent_node = MerkleNode(node_hash.encode('utf-8'))
+                    parent_node = MerkleNode(node_hash)
                     parent_node.left_child, parent_node.right_child = left_child, right_child
                     left_child.parent = parent_node
                     right_child.parent = parent_node
@@ -39,5 +39,5 @@ class MerkleTree:
             nodes = new_level
         self.root = nodes[0]
 
-    def get_root_hash(self) -> bytes:
-        return self.root.hash if self.root else b''
+    def get_root_hash(self) -> str:
+        return self.root.hash if self.root else ''


### PR DESCRIPTION
With this changes we are able to broadcast the block to other peers.
I added the merkle_hash variable to block so we can have the hash without needing to serialize the MerkleTree instance.


