### PR TITLE
Fix problem of creating block so often

### DIFF
--- a/block.py
+++ b/block.py
@@ -10,12 +10,12 @@ class Block(VariablePayload):
     format_list = ['varlenHutf8', 'varlenHutf8', 'varlenH-list']
     names = ['previous_hash', 'merkle_hash', 'transactions']
 
-    def __init__(self, previous_hash: str = '', merkle_hash: str = '', transactions: List[bytes] = []):
+    def __init__(self, previous_hash: str = '', merkle_hash: str = None, transactions: List[bytes] = None):
         # super().__init__()
         self.previous_hash = previous_hash
-        self.transactions = transactions
+        self.transactions = [] if transactions is None else transactions
         self.merkle_tree = MerkleTree()
-        self.merkle_hash = merkle_hash
+        self.merkle_hash = '' if merkle_hash is None else merkle_hash
 
     def add_transaction(self, transaction: Transaction):
         # We serialize the transaction before appending it to the array

--- a/main.py
+++ b/main.py
@@ -166,7 +166,7 @@ class MyCommunity(Community):
                 new_balances[tx.sender] -= tx. amount
                 new_balances[tx.receiver] += tx.amount
 
-                if tx_hash in list(self.pending_txs.keys()):
+                if tx_hash in self.pending_txs.keys():
                     self.pending_txs.pop(tx_hash)
 
                 valid_txs.append(tx.get_tx_bytes())

--- a/main.py
+++ b/main.py
@@ -213,6 +213,8 @@ class MyCommunity(Community):
 
             self.known_peers_mid.add(payload.mid)
 
+            self.known_peers_mid = set(sorted(list(self.known_peers_mid)))
+
             peers = self.get_peers()
             peerMessage = PeersMessage(payload.mid, payload.ttl - 1)
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import binascii
 import logging
-import random
+import random as random
+import random as random2
 import sys
 from asyncio import run
 from collections import defaultdict
@@ -83,8 +84,7 @@ class MyCommunity(Community):
             return
 
         # logging.info(f'[Node {self.get_peer_id(self.my_peer)}] Creating transaction')
-        random.seed()
-        receiver_peer = random.choice([i for i in self.get_peers()])
+        receiver_peer = random2.choice([i for i in self.get_peers()])
 
         # ttl = 3 when creating a tx
         tx = Transaction(self.my_peer.mid, receiver_peer.mid, 10, nonce=self.counter)
@@ -139,8 +139,7 @@ class MyCommunity(Community):
         if tx.ttl > 0:
             tx.ttl -= 1
             # push gossip to k random peers
-            random.seed()
-            get_peers_to_distribute = random.sample(self.get_peers(), min(k, len(self.get_peers())))
+            get_peers_to_distribute = random2.sample(self.get_peers(), min(k, len(self.get_peers())))
             for peer in get_peers_to_distribute:
                 self.ez_send(peer, tx)
 
@@ -178,8 +177,7 @@ class MyCommunity(Community):
         if payload.ttl > 0:
             payload.ttl -= 1
 
-            random.seed()
-            get_peers_to_distribute = random.sample(self.get_peers(), min(k, len(self.get_peers())))
+            get_peers_to_distribute = random2.sample(self.get_peers(), min(k, len(self.get_peers())))
             for peer in get_peers_to_distribute:
                 self.ez_send(peer, payload)
 

--- a/main.py
+++ b/main.py
@@ -56,8 +56,6 @@ class MyCommunity(Community):
         self.add_message_handler(BlockMessage, self.receive_block)
         self.add_message_handler(PeersMessage, self.receive_peers)
 
-        # Use any number as seed
-        random.seed(21)
 
     def started(self, id) -> None:
         logging.info('Community started')
@@ -68,8 +66,8 @@ class MyCommunity(Community):
         random_transaction_interval = random.randint(5, 10)
         self.register_task("tx_create", self.create_transaction, delay=7, interval=random_transaction_interval)
 
-        random_check_interval = random.randint(5, 10)
-        self.register_task("check_txs", self.block_creation, delay=7, interval=random_check_interval)
+        # random_check_interval = random.randint(5, 10)
+        self.register_task("check_txs", self.block_creation, delay=7, interval=5)
 
         self.register_task("send_peers", self.send_peers, delay=5)
 
@@ -85,6 +83,7 @@ class MyCommunity(Community):
             return
 
         # logging.info(f'[Node {self.get_peer_id(self.my_peer)}] Creating transaction')
+        random.seed()
         receiver_peer = random.choice([i for i in self.get_peers()])
 
         # ttl = 3 when creating a tx
@@ -101,12 +100,13 @@ class MyCommunity(Community):
 
 
     def block_creation(self):
+        # WIP: use hash of 2 or 3 previous block as seed
+        random.seed(len(self.blocks))
         selected_peer_mid = random.choice(list(self.known_peers_mid))
 
         if not selected_peer_mid == self.my_peer.mid:
             return
 
-        # logging.info(f'[Node {self.get_peer_id(self.my_peer)}] is creating a block')
         for tx_hash in list(self.pending_txs.keys()):
             tx = self.pending_txs.pop(tx_hash)
             self.finalized_txs[tx_hash] = tx
@@ -135,17 +135,18 @@ class MyCommunity(Community):
             return
 
         logging.info(f'[Node {my_id}]: signature correct')
-        self.pending_txs[tx.get_tx_hash()] = tx
+        self.pending_txs[tx_hash] = tx
         if tx.ttl > 0:
             tx.ttl -= 1
             # push gossip to k random peers
+            random.seed()
             get_peers_to_distribute = random.sample(self.get_peers(), min(k, len(self.get_peers())))
             for peer in get_peers_to_distribute:
                 self.ez_send(peer, tx)
 
     @lazy_wrapper(BlockMessage)
     async def receive_block(self, peer: Peer, payload: BlockMessage) -> None:
-        logging.info('----------on block----------')
+        logging.info(f'[Node {self.get_peer_id(self.my_peer)}] ----------on block----------')
 
         # If the block is already our chain we do nothing
         if payload.hash in [block.get_merkle_hash() for block in self.blocks]:
@@ -165,7 +166,7 @@ class MyCommunity(Community):
                 new_balances[tx.sender] -= tx. amount
                 new_balances[tx.receiver] += tx.amount
 
-                if tx_hash in self.pending_txs:
+                if tx_hash in list(self.pending_txs.keys()):
                     self.pending_txs.pop(tx_hash)
 
                 valid_txs.append(tx.get_tx_bytes())
@@ -177,6 +178,7 @@ class MyCommunity(Community):
         if payload.ttl > 0:
             payload.ttl -= 1
 
+            random.seed()
             get_peers_to_distribute = random.sample(self.get_peers(), min(k, len(self.get_peers())))
             for peer in get_peers_to_distribute:
                 self.ez_send(peer, payload)
@@ -185,7 +187,7 @@ class MyCommunity(Community):
         self.current_block.update_tree()
         new_block_hash = self.current_block.get_merkle_hash()
         # logging.info(f'New block hash: {new_block_hash}')
-        self.blocks.append(self.current_block)
+        # self.blocks.append(self.current_block)
 
         self.broadcast_block(new_block_hash, self.current_block)
         self.current_block = Block(new_block_hash)


### PR DESCRIPTION
Yesterday during the presentation, we encountered an issue where blocks were being created too frequently. The problem was because of the information we set in a new instance of a block: `Block(new_block_hash)`. This was resulting in the new block instance being created with data inside the transactions array. This is why I made changes to the init of `block.py`.

Additionally, I modified the call to `random.seed` so that it is invoked every time we use the random object. This adjustment was necessary because if we set the seed in the constructor of main, it affects every function call of this object.